### PR TITLE
Add some files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,8 @@ libtool
 avecado
 avecado_server
 *.o
-**/.deps/
-**/.dirstamp
+.deps/
+.dirstamp
 include/vector_tile.pb.h
 src/vector_tile.pb.cc
 libavecado.la
@@ -42,6 +42,7 @@ avecado.la
 liblogging.la
 
 # tests
+test-suite.log
 test-driver
 test/make_vector_tile
 test/generalizer


### PR DESCRIPTION
The old gitignore was missing some files

```
src/http_server/.deps/
src/http_server/.dirstamp
src/post_process/.deps/
src/post_process/.dirstamp
```

were all being picked up by git as modified. Not quite sure why the old gitignore didn't pick them up, but there's nothing wrong with the changes.
