### PR TITLE
Hacked around Boost ASIO to allow binding on all interfaces.

### DIFF
--- a/src/avecado_server.cpp
+++ b/src/avecado_server.cpp
@@ -156,7 +156,7 @@ int main(int argc, char *argv[]) {
     mapnik::datasource_cache::instance().register_datasources(input_plugins_dir);
 
     // start the server running
-    http::server3::server server("*", srv_opts);
+    http::server3::server server("0.0.0.0", srv_opts);
     server.run(true);
 
   } catch (std::exception& e) {

--- a/src/http_server/server.cpp
+++ b/src/http_server/server.cpp
@@ -66,13 +66,6 @@ server::server(const std::string& address, const server_options &options)
   tcp::resolver::query query(address, port_);
   tcp::endpoint endpoint = *resolver.resolve(query);
 
-  if (address == "*") {
-    // for some reason, resolving the address "*" results in a localhost
-    // address, rather than all the local interfaces as intended. this hack
-    // forces the endpoint back to all interfaces.
-    endpoint = tcp::endpoint(tcp::v4(), endpoint.port());
-  }
-
   // Open the acceptor with the option to reuse the address (i.e. SO_REUSEADDR).
   acceptor_.open(endpoint.protocol());
   acceptor_.set_option(tcp::acceptor::reuse_address(true));


### PR DESCRIPTION
As @veejaykrishnan reported in #34, the `avecado_server` isn't listening on all network interfaces, making it only accessible from localhost. This wasn't the intention, and this patch forces the server to listen on all interfaces when that's what the `address` parameter was set to.
