### PR TITLE
Added bulk exporter tool

### DIFF
--- a/src/avecado_exporter.cpp
+++ b/src/avecado_exporter.cpp
@@ -4,8 +4,10 @@
 #include <boost/property_tree/exceptions.hpp>
 #include <boost/utility/typed_in_place_factory.hpp>
 #include <boost/format.hpp>
+#include <boost/filesystem.hpp>
 #include <fstream>
 #include <stdexcept>
+#include <future>
 
 #include <mapnik/utils.hpp>
 #include <mapnik/load_map.hpp>
@@ -23,7 +25,13 @@
 
 namespace bpo = boost::program_options;
 namespace bpt = boost::property_tree;
+namespace bfs = boost::filesystem;
 
+/**
+ * common options for generating vector tiles. this is just a
+ * utility class to keep them all in the same place and not need
+ * to change many code paths if we add new ones.
+ */
 struct vector_options {
   unsigned int path_multiplier;
   int buffer_size;
@@ -58,6 +66,307 @@ struct vector_options {
       ;
   }
 };
+
+/**
+ * simple locked queue to track the tiles which need to be
+ * generated. this is used across multiple threads, so needs to
+ * be thread-safe. at high concurrency, it's possible that the
+ * simple mutex lock might be contended, but given the amount of
+ * time spent fetching data from a database / datasource, it's
+ * likely to be a small overhead.
+ */
+struct tile_queue {
+  int min_z, max_z, mask_z, z, x, y;
+  std::mutex mutex;
+
+  tile_queue(int min_z_, int max_z_, int mask_z_)
+    : min_z(min_z_), max_z(max_z_), mask_z(mask_z_),
+      z(min_z), x(0), y(0) {
+  }
+
+  // this is stateful and shared between threads, so we don't
+  // want it being copied as that would lead to threads
+  // duplicating work.
+  tile_queue(const tile_queue &) = delete;
+
+  // if there are any tiles remaining to be done, returns true
+  // and puts the tile coordinates in `root_z`, `root_x` and
+  // `root_y`. the `leaf_z` parameter is filled out with the
+  // depth of the tree to recurse down to. this is only done for
+  // levels above the mask zoom level, where empty tile children
+  // can be omitted.
+  //
+  // if no tiles remain, returns false.
+  bool next(int &root_z, int &root_x, int &root_y, int &leaf_z) {
+    std::unique_lock<std::mutex> lock(mutex);
+
+    if (z > mask_z) {
+      return false;
+
+    } else {
+      root_z = z;
+      root_x = x;
+      root_y = y;
+
+      leaf_z = (z == mask_z) ? max_z : z;
+
+      ++x;
+      if (x >= (1 << z)) {
+        x = 0;
+        ++y;
+      }
+      if (y >= (1 << z)) {
+        y = 0;
+        ++z;
+      }
+
+      return true;
+    }
+  }
+};
+
+/**
+ * encapsulates logic for tile generation and storage in a
+ * conventional z/x/y hierarchy. this holds the "long-lived"
+ * and expensive to generate objects such as mapnik::Map
+ * which don't need to be re-initialised after each tile is
+ * generated.
+ */
+struct tile_generator {
+  mapnik::Map map;
+  const std::string output_dir;
+  const vector_options &vopt;
+  const mapnik::scaling_method_e scaling_method;
+  const boost::optional<const avecado::post_processor &> pp;
+
+  tile_generator(const std::string &map_file,
+                 const std::string &fonts_dir,
+                 const std::string &input_plugins_dir,
+                 const std::string &output_dir_,
+                 const vector_options &vopt_,
+                 mapnik::scaling_method_e scaling_method_,
+                 boost::optional<const avecado::post_processor &> pp_)
+    : map(), output_dir(output_dir_), vopt(vopt_),
+      scaling_method(scaling_method_), pp(pp_) {
+
+    // try to register fonts and input plugins
+    mapnik::freetype_engine::register_fonts(fonts_dir);
+    mapnik::datasource_cache::instance().register_datasources(input_plugins_dir);
+
+    // load map config from disk
+    mapnik::load_map(map, map_file);
+  }
+
+  // recursively generate tiles, ending the recursion when either
+  // `max_z` is reached, or a tile is genererated which is empty.
+  void generate(int root_z, int root_x, int root_y, int max_z) {
+    if (make_tile(root_z, root_x, root_y) &&
+        (root_z < max_z)) {
+      generate(root_z + 1, 2 * root_x,     2 * root_y,     max_z);
+      generate(root_z + 1, 2 * root_x + 1, 2 * root_y,     max_z);
+      generate(root_z + 1, 2 * root_x + 1, 2 * root_y + 1, max_z);
+      generate(root_z + 1, 2 * root_x,     2 * root_y + 1, max_z);
+    }
+  }
+
+  // generate and store a single tile, returning true if the tile
+  // had some data in it and false otherwise.
+  bool make_tile(int z, int x, int y) {
+    avecado::tile tile(z, x, y);
+
+    // setup map parameters
+    map.resize(256, 256);
+    map.zoom_to_box(avecado::util::box_for_tile(z, x, y));
+
+    // actually make the vector tile
+    bool painted = avecado::make_vector_tile(
+      tile, vopt.path_multiplier, map, vopt.buffer_size,
+      vopt.scale_factor, vopt.offset_x, vopt.offset_y,
+      vopt.tolerance, vopt.image_format, scaling_method,
+      vopt.scale_denominator, pp);
+
+    // serialise to file
+    bfs::path output_file = (boost::format("%1%/%2%/%3%/%4%.pbf")
+                             % output_dir % z % x % y).str();
+    bfs::create_directories(output_file.parent_path());
+    std::ofstream output(output_file.native());
+    output << tile;
+
+    return painted;
+  }
+};
+
+// thread function for generating a bunch of tiles in parallel.
+// this is done by sharing a queue structure and having each thread
+// pull 'jobs' off it until all the tiles have been generated.
+void make_vector_thread(std::shared_ptr<tile_queue> queue,
+                        std::string map_file,
+                        std::string fonts_dir,
+                        std::string input_plugins_dir,
+                        std::string output_dir,
+                        vector_options vopt,
+                        mapnik::scaling_method_e scaling_method,
+                        boost::optional<const avecado::post_processor &> pp) {
+  tile_generator generator(map_file, fonts_dir, input_plugins_dir, output_dir,
+                           vopt, scaling_method, pp);
+
+  int root_z = 0, root_x = 0, root_y = 0, max_z = 0;
+  while (queue->next(root_z, root_x, root_y, max_z)) {
+    generator.generate(root_z, root_x, root_y, max_z);
+  }
+}
+
+int make_vector_bulk(int argc, char *argv[]) {
+  std::string output_dir;
+  std::string config_file;
+  mapnik::scaling_method_e scaling_method = mapnik::SCALING_NEAR;
+  vector_options vopt;
+  std::string map_file;
+  int min_z, max_z, mask_z, num_threads;
+  std::string fonts_dir, input_plugins_dir;
+
+  bpo::options_description options(
+    "Avecado " VERSION "\n"
+    "\n"
+    "  Usage: avecado vector-bulk [options] <map-file> <max-z>\n"
+    "\n");
+
+  vopt.add(options);
+
+  options.add_options()
+    ("help,h", "Print this help message.")
+    ("config-file,c", bpo::value<std::string>(&config_file),
+     "JSON config file to specify post-processing for data layers.")
+    ("output-dir,o", bpo::value<std::string>(&output_dir)->default_value("tiles"),
+     "Directory to serialise the vector tiles to.")
+    ("fonts", bpo::value<std::string>(&fonts_dir)->default_value(MAPNIK_DEFAULT_FONT_DIR),
+     "Directory to tell Mapnik to look in for fonts.")
+    ("input-plugins", bpo::value<std::string>(&input_plugins_dir)
+     ->default_value(MAPNIK_DEFAULT_INPUT_PLUGIN_DIR),
+     "Directory to tell Mapnik to look in for input plugins.")
+    ("scaling-method,m", bpo::value<std::string>()->default_value("near"),
+     "Method used to re-sample raster layers.")
+    ("mask-z", bpo::value<int>(), "Mask value, below which empty tiles are discarded.")
+    ("min-z", bpo::value<int>(&min_z)->default_value(0),
+     "Minimum zoom level to generate.")
+    ("parallel,P", bpo::value<int>(&num_threads)->default_value(1),
+     "Number of parallel processes to run when generating tiles.")
+    // positional arguments
+    ("map-file", bpo::value<std::string>(&map_file), "Mapnik XML input file.")
+    ("max-z", bpo::value<int>(&max_z), "Maximum zoom level to generate.")
+    ;
+
+  bpo::positional_options_description pos_options;
+  pos_options
+    .add("map-file", 1)
+    .add("max-z", 1)
+    ;
+
+  bpo::variables_map vm;
+
+  try {
+    bpo::store(bpo::command_line_parser(argc,argv)
+               .options(options)
+               .positional(pos_options)
+               .run(),
+               vm);
+    bpo::notify(vm);
+
+  } catch (std::exception & e) {
+    std::cerr << "Unable to parse command line options because: " << e.what() << "\n"
+              << "This is a bug, please report it at " PACKAGE_BUGREPORT << "\n";
+    return EXIT_FAILURE;
+  }
+
+  if (vm.count("help")) {
+    std::cout << options << "\n";
+    return EXIT_SUCCESS;
+  }
+
+  // argument checking and verification
+  for (auto arg : {"map-file", "max-z"}) {
+    if (vm.count(arg) == 0) {
+      std::cerr << "The <" << arg << "> argument was not provided, but is mandatory\n\n";
+      std::cerr << options << "\n";
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (vm.count("mask-z")) {
+    mask_z = vm["mask-z"].as<int>();
+
+  } else {
+    // default is to not mask any zoom levels, which is the same as
+    // setting mask = max.
+    mask_z = max_z;
+  }
+
+  if (vm.count("scaling-method")) {
+    std::string method_str(vm["scaling-method"].as<std::string>());
+
+    boost::optional<mapnik::scaling_method_e> method =
+      mapnik::scaling_method_from_string(method_str);
+
+    if (!method) {
+      std::cerr << "The string \"" << method_str << "\" was not recognised as a "
+                << "valid scaling method by Mapnik.\n";
+      return EXIT_FAILURE;
+    }
+
+    scaling_method = *method;
+  }
+
+  // load post processor config if it is provided
+  avecado::post_processor post_processor;
+  boost::optional<const avecado::post_processor &> pp;
+  if (!config_file.empty()) {
+    try {
+      // parse json config
+      bpt::ptree config;
+      bpt::read_json(config_file, config);
+      // init processor
+      post_processor.load(config);
+      pp = post_processor;
+
+    } catch (bpt::ptree_error const& e) {
+      std::cerr << "Error while parsing config: " << config_file << std::endl;
+      std::cerr << e.what() << std::endl;
+      return EXIT_FAILURE;
+    } catch (std::exception const& e) {
+      std::cerr << "Error while loading config: " << config_file << std::endl;
+      std::cerr << e.what() << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (num_threads < 1) {
+    std::cerr << "Number of parallel threads must be at least one." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  try {
+    std::shared_ptr<tile_queue> queue =
+      std::make_shared<tile_queue>(min_z, max_z, mask_z);
+
+    std::vector<std::future<void> > threads;
+    for (int i = 0; i < num_threads; ++i) {
+      threads.emplace_back(std::async(std::launch::async,
+                                      &make_vector_thread,
+                                      queue, map_file, fonts_dir, input_plugins_dir,
+                                      output_dir, vopt, scaling_method, pp));
+    }
+
+    for (auto &fut : threads) {
+      fut.get();
+    }
+
+  } catch (const std::exception &e) {
+    std::cerr << "Unable to make vector tile: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}
 
 int make_vector(int argc, char *argv[]) {
   std::string output_file;
@@ -334,7 +643,10 @@ int main(int argc, char *argv[]) {
       new_argv[i] = argv[i+1];
     }
 
-    if (command == "vector") {
+    if (command == "vector-bulk") {
+      return make_vector_bulk(new_argc, new_argv);
+
+    } else if (command == "vector") {
       return make_vector(new_argc, new_argv);
 
     } else if (command == "raster") {
@@ -349,8 +661,10 @@ int main(int argc, char *argv[]) {
     "avecado <command> [command-options]\n"
     "\n"
     "Where command is:\n"
-    "  vector: Avecado will make vector tiles from a Mapnik XML\n"
-    "          file and export them as PBFs.\n"
+    "  vector-bulk: Avecado will make a range of vector tiles from a\n"
+    "               Mapnik XML file and export them as PBFs.\n"
+    "  vector: Avecado will make a single vector tile from a Mapnik\n"
+    "          XML file and export it as a PBF.\n"
     "  raster: Avecado will make raster tiles from vector tiles\n"
     "          plus a style file.\n"
     "\n"


### PR DESCRIPTION
This hierarchically generates tiles for a range of zooms, with the option of specifying a masking zoom below which any empty tile's sub-trees will be omitted. This makes tile generation for empty areas faster, although at present it doesn't detect the case of a single background polygon (i.e: ocean), so isn't as efficient as it could be.
