### PR TITLE
Allow ignoring layers to control recursion.

### DIFF
--- a/src/avecado_exporter.cpp
+++ b/src/avecado_exporter.cpp
@@ -274,7 +274,7 @@ void make_vector_thread(std::shared_ptr<tile_queue> queue,
 
   } catch (const std::exception &e) {
     stop_all_threads.store(true);
-    throw e;
+    throw;
 
   } catch (...) {
     stop_all_threads.store(true);


### PR DESCRIPTION
When `z > maskLevel`, the bulk exporter will generate the child tiles of a particular tile only if that tile is non-empty. It does this by looking at whether it "painted", which means it generated some features in the output.

However, this doesn't work all that well when it detects the ocean polygon as "painted" and recurses into boring ocean. This patch allows the user to specify which layers to ignore when making the decision about whether to generate child tiles.
