### PR TITLE
Fix server abort

### DIFF
--- a/include/http_server/server.hpp
+++ b/include/http_server/server.hpp
@@ -14,6 +14,7 @@
 #include <boost/asio.hpp>
 #include <string>
 #include <vector>
+#include <exception>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread.hpp>
@@ -92,6 +93,9 @@ private:
 
    /// The thread pool
    std::vector<boost::shared_ptr<boost::thread> > threads_;
+
+   /// Captured errors for the threads
+   std::vector<std::exception_ptr> thread_errors_;
 };
 
 } // namespace server3

--- a/src/avecado_server.cpp
+++ b/src/avecado_server.cpp
@@ -161,6 +161,7 @@ int main(int argc, char *argv[]) {
 
   } catch (std::exception& e) {
     std::cerr << "Exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
   }
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
Returned exception from thread, rather than allowing it to abort the process. Fixes #51.
