### PR TITLE
Update Mapnik-Vector-Tile

### DIFF
--- a/include/backend.hpp
+++ b/include/backend.hpp
@@ -22,7 +22,7 @@ class post_processor;
 
 class backend {
 public:
-  backend(mapnik::vector::tile & tile,
+  backend(vector_tile::Tile & tile,
           unsigned path_multiplier,
           mapnik::Map const& map,
           boost::optional<const post_processor &> pp);
@@ -58,7 +58,7 @@ public:
   }
 
 private:
-  mapnik::vector::backend_pbf m_pbf;
+  mapnik::vector_tile_impl::backend_pbf m_pbf;
   mapnik::Map const& m_map;
   unsigned int m_tolerance;
   boost::optional<const post_processor &> m_post_processor;

--- a/include/tile.hpp
+++ b/include/tile.hpp
@@ -7,7 +7,7 @@
 /* Forward declaration of vector tile type. This type is opaque
  * to users of Avecado, but we expose some methods in the
  * exported vector tile object below. */
-namespace mapnik { namespace vector { struct tile; } }
+namespace vector_tile { struct Tile; }
 
 namespace avecado {
 
@@ -31,14 +31,14 @@ public:
   void from_string(const std::string &str);
 
   // Return the in-memory structure of the tile.
-  mapnik::vector::tile const &mapnik_tile() const;
-  mapnik::vector::tile &mapnik_tile();
+  vector_tile::Tile const &mapnik_tile() const;
+  vector_tile::Tile &mapnik_tile();
 
   // coordinates of this tile
   const unsigned int z, x, y;
 
 private:
-  std::unique_ptr<mapnik::vector::tile> m_mapnik_tile;
+  std::unique_ptr<vector_tile::Tile> m_mapnik_tile;
 };
 
 // read the tile from a zero-copy input stream

--- a/include/util_tile.hpp
+++ b/include/util_tile.hpp
@@ -3,7 +3,7 @@
 
 #include "tile.hpp"
 
-namespace mapnik { namespace vector { struct tile_layer; } }
+namespace vector_tile { struct Tile_Layer; }
 
 namespace avecado { namespace util {
 
@@ -16,7 +16,7 @@ namespace avecado { namespace util {
  * will be true of all descendants and the subtree can be
  * skipped.
  */
-bool is_interesting(const mapnik::vector::tile_layer &);
+bool is_interesting(const vector_tile::Tile_Layer &);
 
 } } // namespace avecado::util
 

--- a/src/avecado_exporter.cpp
+++ b/src/avecado_exporter.cpp
@@ -752,7 +752,7 @@ int make_raster(int argc, char *argv[]) {
 
       std::unique_ptr<avecado::tile> tile(std::move(response.left()));
       avecado::render_vector_tile(image, *tile, map, scale_factor, buffer_size);
-      mapnik::save_to_file(image, output_file, "png");
+      mapnik::save_to_file(image.data(), output_file, "png");
 
     } else {
       throw std::runtime_error((boost::format("Error while fetching tile: %1%")

--- a/src/avecado_exporter.cpp
+++ b/src/avecado_exporter.cpp
@@ -272,7 +272,7 @@ struct tile_generator {
       // if there all layers which are ignored or uninteresting,
       // then we can ignore the whole tile, even if it painted
       // something.
-      for (const mapnik::vector::tile_layer &layer : tile.mapnik_tile().layers()) {
+      for (const vector_tile::Tile_Layer &layer : tile.mapnik_tile().layers()) {
         if ((layer.has_name()) &&
             (ignore_layers.count(layer.name()) == 0) &&
             (avecado::util::is_interesting(layer))) {

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -3,7 +3,7 @@
 
 namespace avecado {
 
-backend::backend(mapnik::vector::tile & tile,
+backend::backend(vector_tile::Tile & tile,
                  unsigned path_multiplier,
                  mapnik::Map const& map,
                  boost::optional<const post_processor &> pp)

--- a/src/make_vector_tile.cpp
+++ b/src/make_vector_tile.cpp
@@ -24,7 +24,7 @@ bool make_vector_tile(tile &tile,
                       boost::optional<const post_processor &> pp) {
   
   typedef backend backend_type;
-  typedef mapnik::vector::processor<backend_type> renderer_type;
+  typedef mapnik::vector_tile_impl::processor<backend_type> renderer_type;
   
   backend_type backend(tile.mapnik_tile(), path_multiplier, map, pp);
   

--- a/src/render_vector_tile.cpp
+++ b/src/render_vector_tile.cpp
@@ -25,7 +25,7 @@ namespace {
  * the two can be different due to overzooming.
  */
 void process_layers(std::vector<mapnik::layer> const &layers,
-                    mapnik::vector::tile const &tile,
+                    vector_tile::Tile const &tile,
                     mapnik::request &request,
                     unsigned int z, unsigned int x, unsigned int y,
                     mapnik::projection const &projection,
@@ -45,7 +45,7 @@ void process_layers(std::vector<mapnik::layer> const &layers,
           mapnik::layer layer_copy(layer);
 
           layer_copy.set_datasource(
-            std::make_shared<mapnik::vector::tile_datasource>(
+            std::make_shared<mapnik::vector_tile_impl::tile_datasource>(
               layer_data, x, y, z, request.width()));
 
           std::set<std::string> names;
@@ -74,7 +74,7 @@ bool render_vector_tile(mapnik::image_32 &image,
   // them from.
   mapnik::attributes variables;
 
-  mapnik::vector::tile const &tile = avecado_tile.mapnik_tile();
+  vector_tile::Tile const &tile = avecado_tile.mapnik_tile();
 
   mapnik::request request(map.width(),
                           map.height(),

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -7,7 +7,7 @@
 namespace avecado {
 
 tile::tile(unsigned int z_, unsigned int x_, unsigned int y_)
-  : z(z_), x(x_), y(y_), m_mapnik_tile(new mapnik::vector::tile) {
+  : z(z_), x(x_), y(y_), m_mapnik_tile(new vector_tile::Tile) {
 }
 
 tile::~tile() {
@@ -26,11 +26,11 @@ void tile::from_string(const std::string &str) {
   m_mapnik_tile.swap(t.m_mapnik_tile);
 }
 
-mapnik::vector::tile const &tile::mapnik_tile() const {
+vector_tile::Tile const &tile::mapnik_tile() const {
   return *m_mapnik_tile;
 }
 
-mapnik::vector::tile &tile::mapnik_tile() {
+vector_tile::Tile &tile::mapnik_tile() {
   return *m_mapnik_tile;
 }
 

--- a/src/util_tile.cpp
+++ b/src/util_tile.cpp
@@ -41,7 +41,7 @@ struct minmax {
 
 } // anonymous namespace
 
-bool is_interesting(const mapnik::vector::tile_layer &l) {
+bool is_interesting(const vector_tile::Tile_Layer &l) {
   // empty features are not interesting
   if (l.features_size() == 0) {
     return false;
@@ -54,7 +54,7 @@ bool is_interesting(const mapnik::vector::tile_layer &l) {
 
   // now we know there's one feature, we can see if the
   // geometry is interesting, which means decoding the tile.
-  const mapnik::vector::tile_feature &f = l.features(0);
+  const vector_tile::Tile_Feature &f = l.features(0);
 
   const int32_t extent = l.extent();
   const uint32_t geometry_size = f.geometry_size();

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -233,7 +233,7 @@ void test_tile_is_not_compressed() {
   // because it needs to avoid any automatic ungzipping.
   stream.seekp(0);
   google::protobuf::io::IstreamInputStream gstream(&stream);
-  mapnik::vector::tile tile;
+  vector_tile::Tile tile;
   bool read_ok = tile.ParseFromZeroCopyStream(&gstream);
   test::assert_equal<bool>(read_ok, true, "tile was plain PBF");
 }

--- a/test/make_vector_tile.cpp
+++ b/test/make_vector_tile.cpp
@@ -70,13 +70,13 @@ void test_single_point() {
                             scaling_method, scale_denominator, boost::none);
   avecado::tile tile2(_z, _x, _y);
   tile2.from_string(tile.get_data());
-  const mapnik::vector::tile &result = tile2.mapnik_tile();
+  const vector_tile::Tile &result = tile2.mapnik_tile();
 
   test::assert_equal(result.layers_size(), 1, "Wrong number of layers");
-  mapnik::vector::tile_layer layer = result.layers(0);
+  vector_tile::Tile_Layer layer = result.layers(0);
 
   // Query the layer with mapnik. See https://github.com/mapbox/mapnik-vector-tile/blob/2e3e2c28/test/vector_tile.cpp#L236
-  mapnik::vector::tile_datasource ds(layer, 0, 0, 0, tile_size);
+  mapnik::vector_tile_impl::tile_datasource ds(layer, 0, 0, 0, tile_size);
 
   mapnik::query qq = mapnik::query(bbox);
   qq.add_property_name("name");
@@ -98,13 +98,13 @@ void test_single_line() {
                             scaling_method, scale_denominator, boost::none);
   avecado::tile tile2(_z, _x, _y);
   tile2.from_string(tile.get_data());
-  const mapnik::vector::tile &result = tile2.mapnik_tile();
+  const vector_tile::Tile &result = tile2.mapnik_tile();
 
   test::assert_equal(result.layers_size(), 1, "Wrong number of layers");
-  mapnik::vector::tile_layer layer = result.layers(0);
+  vector_tile::Tile_Layer layer = result.layers(0);
 
   // Query the layer with mapnik. See https://github.com/mapbox/mapnik-vector-tile/blob/2e3e2c28/test/vector_tile.cpp#L236
-  mapnik::vector::tile_datasource ds(layer, 0, 0, 0, tile_size);
+  mapnik::vector_tile_impl::tile_datasource ds(layer, 0, 0, 0, tile_size);
 
   mapnik::query qq = mapnik::query(bbox);
   qq.add_property_name("name");
@@ -126,13 +126,13 @@ void test_single_polygon() {
                             scaling_method, scale_denominator, boost::none);
   avecado::tile tile2(_z, _x, _y);
   tile2.from_string(tile.get_data());
-  const mapnik::vector::tile &result = tile2.mapnik_tile();
+  const vector_tile::Tile &result = tile2.mapnik_tile();
 
   test::assert_equal(result.layers_size(), 1, "Wrong number of layers");
-  mapnik::vector::tile_layer layer = result.layers(0);
+  vector_tile::Tile_Layer layer = result.layers(0);
 
   // Query the layer with mapnik. See https://github.com/mapbox/mapnik-vector-tile/blob/2e3e2c28/test/vector_tile.cpp#L236
-  mapnik::vector::tile_datasource ds(layer, 0, 0, 0, tile_size);
+  mapnik::vector_tile_impl::tile_datasource ds(layer, 0, 0, 0, tile_size);
 
   mapnik::query qq = mapnik::query(bbox);
   qq.add_property_name("name");
@@ -154,14 +154,14 @@ void test_intersected_line() {
                             scaling_method, scale_denominator, boost::none);
   avecado::tile tile2(_z, _x, _y);
   tile2.from_string(tile.get_data());
-  const mapnik::vector::tile &result = tile2.mapnik_tile();
+  const vector_tile::Tile &result = tile2.mapnik_tile();
 
   test::assert_equal(result.layers_size(), 1, "Wrong number of layers");
-  mapnik::vector::tile_layer layer = result.layers(0);
+  vector_tile::Tile_Layer layer = result.layers(0);
 
   // Query the layer with mapnik. See https://github.com/mapbox/mapnik-vector-tile/blob/2e3e2c28/test/vector_tile.cpp#L236
   // note tile_datasource has x, y, z
-  mapnik::vector::tile_datasource ds(layer, 0, 0, 1, tile_size);
+  mapnik::vector_tile_impl::tile_datasource ds(layer, 0, 0, 1, tile_size);
 
   mapnik::query qq = mapnik::query(avecado::util::box_for_tile(1, 0, 0));
   qq.add_property_name("name");

--- a/test/multi_verification.cpp
+++ b/test/multi_verification.cpp
@@ -63,13 +63,13 @@ void test_multiline() {
                             scaling_method, scale_denominator, boost::none);
   avecado::tile tile2(_z, _x, _y);
   tile2.from_string(tile.get_data());
-  const mapnik::vector::tile &result = tile2.mapnik_tile();
+  const vector_tile::Tile &result = tile2.mapnik_tile();
 
   test::assert_equal(result.layers_size(), 1, "Wrong number of layers");
-  mapnik::vector::tile_layer layer = result.layers(0);
+  vector_tile::Tile_Layer layer = result.layers(0);
   test::assert_equal(layer.name(), std::string ("point"), "Wrong layer name");
   test::assert_equal(layer.features_size(), 1, "Wrong number of features");
-  mapnik::vector::tile_feature feature = layer.features(0);
+  vector_tile::Tile_Feature feature = layer.features(0);
   test::assert_equal(int(feature.type()), 2, "Wrong feature type");
   // The geometry should be a move to, lineto, moveto, lineto
   test::assert_equal(feature.geometry_size(), 12, "Wrong feature geometry length");
@@ -83,7 +83,7 @@ void test_multiline() {
   /* If we're this far, the PBF checks out */
 
   // Query the layer with mapnik. See https://github.com/mapbox/mapnik-vector-tile/blob/2e3e2c28/test/vector_tile.cpp#L236
-  mapnik::vector::tile_datasource ds(layer, 0, 0, 0, tile_size);
+  mapnik::vector_tile_impl::tile_datasource ds(layer, 0, 0, 0, tile_size);
 
   mapnik::query qq = mapnik::query(bbox);
   qq.add_property_name("name");
@@ -115,13 +115,13 @@ void test_multipolygon() {
                             scaling_method, scale_denominator, boost::none);
   avecado::tile tile2(_z, _x, _y);
   tile2.from_string(tile.get_data());
-  const mapnik::vector::tile &result = tile2.mapnik_tile();
+  const vector_tile::Tile &result = tile2.mapnik_tile();
 
   test::assert_equal(result.layers_size(), 1, "Wrong number of layers");
-  mapnik::vector::tile_layer layer = result.layers(0);
+  vector_tile::Tile_Layer layer = result.layers(0);
   test::assert_equal(layer.name(), std::string ("point"), "Wrong layer name");
   test::assert_equal(layer.features_size(), 1, "Wrong number of features");
-  mapnik::vector::tile_feature feature = layer.features(0);
+  vector_tile::Tile_Feature feature = layer.features(0);
   test::assert_equal(int(feature.type()), 3, "Wrong feature type");
   // The geometry should be a move to, lineto, moveto, lineto
   test::assert_equal(feature.geometry_size(), 37, "Wrong feature geometry length");

--- a/test/render_vector_tile.cpp
+++ b/test/render_vector_tile.cpp
@@ -68,12 +68,12 @@ void test_full() {
 
   avecado::tile tile(0, 0, 0);
   {
-    mapnik::vector::tile_layer *layer = tile.mapnik_tile().add_layers();
+    vector_tile::Tile_Layer *layer = tile.mapnik_tile().add_layers();
     layer->set_version(1);
     layer->set_name("layer");
-    mapnik::vector::tile_feature *feature = layer->add_features();
+    vector_tile::Tile_Feature *feature = layer->add_features();
     feature->set_id(1);
-    feature->set_type(mapnik::vector::tile::Polygon);
+    feature->set_type(vector_tile::Tile::Polygon);
     // this strange sequence of numbers comes from cranking the mapnik vector
     // tile geometry algorithm by hand on a [-180 -90, 180 90] box.
     for (uint32_t g : {9, 0, 128, 26, 512, 0, 0, 256, 511, 0, 7}) {

--- a/test/util_tile.cpp
+++ b/test/util_tile.cpp
@@ -8,7 +8,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/format.hpp>
 
-using mapnik::vector::tile_layer;
+using vector_tile::Tile_Layer;
 
 namespace {
 
@@ -20,9 +20,9 @@ void test_cover_empty() {
 void test_cover_full() {
   tile_layer l;
   l.set_name("boundingbox");
-  mapnik::vector::tile_feature *feat = l.add_features();
+  vector_tile::Tile_Feature *feat = l.add_features();
   feat->set_id(1);
-  feat->set_type(mapnik::vector::tile::Polygon);
+  feat->set_type(vector_tile::Tile::Polygon);
   for (uint32_t i : {9, 63, 8256, 26, 0, 8319, 8320, 0, 0, 8320, 15}) {
     feat->add_geometry(i);
   }
@@ -36,9 +36,9 @@ void test_cover_full() {
 void test_cover_full_degenerate() {
   tile_layer l;
   l.set_name("water");
-  mapnik::vector::tile_feature *feat = l.add_features();
+  vector_tile::Tile_Feature *feat = l.add_features();
   feat->set_id(2);
-  feat->set_type(mapnik::vector::tile::Polygon);
+  feat->set_type(vector_tile::Tile::Polygon);
   for (uint32_t i : {9, 63, 8256, 58, 0, 8319, 8320, 0, 0, 8320, 8319,
         0, 8320, 0, 8319, 0, 8320, 0, 15}) {
     feat->add_geometry(i);
@@ -53,9 +53,9 @@ void test_cover_many() {
   tile_layer l;
   l.set_name("boundingbox");
   for (int32_t id : {1, 2}) {
-    mapnik::vector::tile_feature *feat = l.add_features();
+    vector_tile::Tile_Feature *feat = l.add_features();
     feat->set_id(id);
-    feat->set_type(mapnik::vector::tile::Polygon);
+    feat->set_type(vector_tile::Tile::Polygon);
     for (uint32_t i : {9, 63, 8256, 26, 0, 8319, 8320, 0, 0, 8320, 15}) {
       feat->add_geometry(i);
     }
@@ -70,9 +70,9 @@ void test_cover_many() {
 void test_cover_shape() {
   tile_layer l;
   l.set_name("boundingbox");
-  mapnik::vector::tile_feature *feat = l.add_features();
+  vector_tile::Tile_Feature *feat = l.add_features();
   feat->set_id(1);
-  feat->set_type(mapnik::vector::tile::Polygon);
+  feat->set_type(vector_tile::Tile::Polygon);
   for (uint32_t i : {9, 63, 8256, 26, 0, 8319, 8320, 0, 0, 8320, 15}) {
     feat->add_geometry(i);
   }


### PR DESCRIPTION
There are some errors with the latest mapnik and `make check`, but `make` builds with ubuntu 14.04, boost 1.56, and mapnik/mapnik@879e9d517bcca8ebc38908d9f47e9054a58262cb