### PR TITLE
Update to Mapnik 87e9c64f

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -82,7 +82,7 @@ libavecado_la_SOURCES = \
 nodist_libavecado_la_SOURCES = \
 	src/vector_tile.pb.cc
 
-libavecado_la_LIBADD = @MAPNIK_LIBS@ @PROTOC_LIBS@ @BOOST_PROGRAM_OPTIONS_LIB@ @LIBCURL_LIBS@
+libavecado_la_LIBADD = @MAPNIK_LIBS@ -lmapnik-json @PROTOC_LIBS@ @BOOST_PROGRAM_OPTIONS_LIB@ @LIBCURL_LIBS@
 
 if HAVE_SQLITE3
 libavecado_la_LIBADD += @SQLITE3_LDFLAGS@

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Avecado uses the [GNU Build System](http://www.gnu.org/software/automake/manual/
 
     sudo apt-get install build-essential autoconf automake libtool libboost-all-dev python-dev libprotobuf-dev protobuf-compiler
 
-You will also need to install a 3.x version of the Mapnik library. This version of the library was tested with commit `01c6b422` from [Mapnik master](https://github.com/mapnik/mapnik).
+You will also need to install a 3.x version of the Mapnik library. This version of the library was tested with commit `87e9c64f` from [Mapnik master](https://github.com/mapnik/mapnik).
 
 Then you should be able to bootstrap the build system:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,8 @@ on running it.
 Avecado embeds [mapnik-vector-tile](https://github.com/mapbox/mapnik-vector-tile)
 as a subrepository. Its version needs to match with Mapnik's. If building on a
 system with an older or newer Mapnik, an older or newer version of
-mapnik-vector-tile should be used. This is complicated, but should stabalize
+mapnik-vector-tile should be used. The version of Mapnik used when testing
+this version of Avecado was `87e9c64f`. This is complicated, but should stabilize
 when Mapnik 3 is released.
 
 ## Components ##

--- a/include/avecado.hpp
+++ b/include/avecado.hpp
@@ -9,9 +9,6 @@
 #include <mapnik/map.hpp>
 #include <mapnik/image_scaling.hpp>
 
-// forward declaration of mapnik's raster image type
-namespace mapnik { class image_32; }
-
 namespace avecado {
 
 /**
@@ -129,7 +126,7 @@ bool make_vector_tile(tile &tile,
  *     normally have an effect. (TODO: check this is what's
  *     actually happening.)
  */
-bool render_vector_tile(mapnik::image_32 &image,
+bool render_vector_tile(mapnik::image_rgba8 &image,
                         tile &tile,
                         mapnik::Map const &map,
                         double scale_factor,

--- a/include/backend.hpp
+++ b/include/backend.hpp
@@ -1,9 +1,6 @@
 #ifndef AVECADO_BACKEND_HPP
 #define AVECADO_BACKEND_HPP
 
-#include "mapnik3x_compatibility.hpp"
-#include MAPNIK_VARIANT_INCLUDE
-
 // mapnik
 #include <mapnik/feature.hpp>
 #include <mapnik/value_types.hpp>
@@ -22,7 +19,7 @@ class post_processor;
 
 class backend {
 public:
-  backend(mapnik::vector::tile & tile,
+  backend(vector_tile::Tile & tile,
           unsigned path_multiplier,
           mapnik::Map const& map,
           boost::optional<const post_processor &> pp);
@@ -38,7 +35,7 @@ public:
   void add_tile_feature_raster(std::string const& image_buffer);
 
   template <typename T>
-  inline unsigned add_path(T & path, unsigned tolerance, MAPNIK_GEOM_TYPE type) {
+  inline unsigned add_path(T & path, unsigned tolerance, mapnik::geometry_type::types type) {
     mapnik::geometry_type * geom = new mapnik::geometry_type(type);
     double x, y;
     unsigned command, count = 0;
@@ -58,7 +55,7 @@ public:
   }
 
 private:
-  mapnik::vector::backend_pbf m_pbf;
+  mapnik::vector_tile_impl::backend_pbf m_pbf;
   mapnik::Map const& m_map;
   unsigned int m_tolerance;
   boost::optional<const post_processor &> m_post_processor;

--- a/include/tile.hpp
+++ b/include/tile.hpp
@@ -7,7 +7,7 @@
 /* Forward declaration of vector tile type. This type is opaque
  * to users of Avecado, but we expose some methods in the
  * exported vector tile object below. */
-namespace mapnik { namespace vector { struct tile; } }
+namespace vector_tile { struct Tile; }
 
 namespace avecado {
 
@@ -31,14 +31,14 @@ public:
   void from_string(const std::string &str);
 
   // Return the in-memory structure of the tile.
-  mapnik::vector::tile const &mapnik_tile() const;
-  mapnik::vector::tile &mapnik_tile();
+  vector_tile::Tile const &mapnik_tile() const;
+  vector_tile::Tile &mapnik_tile();
 
   // coordinates of this tile
   const unsigned int z, x, y;
 
 private:
-  std::unique_ptr<mapnik::vector::tile> m_mapnik_tile;
+  std::unique_ptr<vector_tile::Tile> m_mapnik_tile;
 };
 
 // read the tile from a zero-copy input stream

--- a/include/util_tile.hpp
+++ b/include/util_tile.hpp
@@ -3,7 +3,7 @@
 
 #include "tile.hpp"
 
-namespace mapnik { namespace vector { struct tile_layer; } }
+namespace vector_tile { struct Tile_Layer; }
 
 namespace avecado { namespace util {
 
@@ -16,7 +16,7 @@ namespace avecado { namespace util {
  * will be true of all descendants and the subtree can be
  * skipped.
  */
-bool is_interesting(const mapnik::vector::tile_layer &);
+bool is_interesting(const vector_tile::Tile_Layer &);
 
 } } // namespace avecado::util
 

--- a/src/avecado_exporter.cpp
+++ b/src/avecado_exporter.cpp
@@ -19,7 +19,6 @@
 #include <mapnik/load_map.hpp>
 #include <mapnik/font_engine_freetype.hpp>
 #include <mapnik/datasource_cache.hpp>
-#include <mapnik/graphics.hpp>
 #include <mapnik/image_util.hpp>
 
 #include "avecado.hpp"
@@ -272,7 +271,7 @@ struct tile_generator {
       // if there all layers which are ignored or uninteresting,
       // then we can ignore the whole tile, even if it painted
       // something.
-      for (const mapnik::vector::tile_layer &layer : tile.mapnik_tile().layers()) {
+      for (const vector_tile::Tile_Layer &layer : tile.mapnik_tile().layers()) {
         if ((layer.has_name()) &&
             (ignore_layers.count(layer.name()) == 0) &&
             (avecado::util::is_interesting(layer))) {
@@ -748,7 +747,7 @@ int make_raster(int argc, char *argv[]) {
     avecado::fetch_response response = (*fetcher)(z, x, y).get();
 
     if (response.is_left()) {
-      mapnik::image_32 image(width, height);
+      mapnik::image_rgba8 image(width, height);
 
       std::unique_ptr<avecado::tile> tile(std::move(response.left()));
       avecado::render_vector_tile(image, *tile, map, scale_factor, buffer_size);

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -3,7 +3,7 @@
 
 namespace avecado {
 
-backend::backend(mapnik::vector::tile & tile,
+backend::backend(vector_tile::Tile & tile,
                  unsigned path_multiplier,
                  mapnik::Map const& map,
                  boost::optional<const post_processor &> pp)
@@ -32,7 +32,7 @@ void backend::stop_tile_layer() {
       m_current_image_buffer.reset();
     }
     for (size_t i = 0; i < feature->num_geometries(); i++) {
-      mapnik::geometry_type const& path = feature->get_geometry(i);
+      mapnik::vertex_adapter path(feature->get_geometry(i));
       // See hack note about tolerance below in add_path(...)
       m_pbf.add_path(path, m_tolerance, path.type());
     }
@@ -51,8 +51,8 @@ void backend::start_tile_feature(mapnik::feature_impl const& feature) {
   mapnik::feature_kv_iterator itr = feature.begin();
   mapnik::feature_kv_iterator end = feature.end();
   for ( ;itr!=end; ++itr) {
-    std::string const& name = MAPNIK_GET<0>(*itr);
-    mapnik::value const& val = MAPNIK_GET<1>(*itr);
+    std::string const& name = std::get<0>(*itr);
+    mapnik::value const& val = std::get<1>(*itr);
     m_current_feature->put_new(name, val);
   }
 }

--- a/src/make_vector_tile.cpp
+++ b/src/make_vector_tile.cpp
@@ -4,7 +4,6 @@
 #include <mapnik/map.hpp>
 #include <mapnik/feature.hpp>
 
-#include "mapnik3x_compatibility.hpp"
 #include "vector_tile_processor.hpp"
 #include "backend.hpp"
 
@@ -24,7 +23,7 @@ bool make_vector_tile(tile &tile,
                       boost::optional<const post_processor &> pp) {
   
   typedef backend backend_type;
-  typedef mapnik::vector::processor<backend_type> renderer_type;
+  typedef mapnik::vector_tile_impl::processor<backend_type> renderer_type;
   
   backend_type backend(tile.mapnik_tile(), path_multiplier, map, pp);
   

--- a/src/post_process/adminizer.cpp
+++ b/src/post_process/adminizer.cpp
@@ -179,11 +179,12 @@ multi_point_2d make_boost_point(const mapnik::geometry_type &geom) {
   multi_point_2d points;
   double x = 0, y = 0;
 
-  geom.rewind(0);
+  mapnik::vertex_adapter path(geom);
+  path.rewind(0);
 
   unsigned int cmd = mapnik::SEG_END;
 
-  while ((cmd = geom.vertex(&x, &y)) != mapnik::SEG_END) {
+  while ((cmd = path.vertex(&x, &y)) != mapnik::SEG_END) {
     points.push_back(bg::make<point_2d>(x, y));
   }
   return points;
@@ -193,10 +194,11 @@ multi_linestring_2d make_boost_linestring(const mapnik::geometry_type &geom) {
   multi_linestring_2d line;
   double x = 0, y = 0, prev_x = 0, prev_y = 0;
 
-  geom.rewind(0);
+  mapnik::vertex_adapter path(geom);
+  path.rewind(0);
 
   unsigned int cmd = mapnik::SEG_END;
-  while ((cmd = geom.vertex(&x, &y)) != mapnik::SEG_END) {
+  while ((cmd = path.vertex(&x, &y)) != mapnik::SEG_END) {
 
     if (cmd == mapnik::SEG_MOVETO) {
       line.push_back(linestring_2d());
@@ -222,10 +224,11 @@ polygon_2d make_boost_polygon(const mapnik::geometry_type &geom) {
   double x = 0, y = 0, prev_x = 0, prev_y = 0, first_x = 0, first_y = 0;
   unsigned int ring_count = 0;
 
-  geom.rewind(0);
+  mapnik::vertex_adapter path(geom);
+  path.rewind(0);
 
   unsigned int cmd = mapnik::SEG_END;
-  while ((cmd = geom.vertex(&x, &y)) != mapnik::SEG_END) {
+  while ((cmd = path.vertex(&x, &y)) != mapnik::SEG_END) {
 
     if (cmd == mapnik::SEG_MOVETO) {
       if (ring_count == 0) {

--- a/src/post_process/generalizer.cpp
+++ b/src/post_process/generalizer.cpp
@@ -39,23 +39,27 @@ void generalizer::process(vector<mapnik::feature_ptr> &layer, mapnik::Map const&
     //for each geometry
     for(size_t i = 0; i < feat->num_geometries(); ++i) {
       //grab the geom
-      mapnik::geometry_type& geom = feat->get_geometry(i);
+      const mapnik::geometry_type &geom = feat->get_geometry(i);
+      // adapt it as a path
+      mapnik::vertex_adapter path(geom);
       //setup the generalization
-      mapnik::simplify_converter<mapnik::geometry_type> generalizer(geom);
+      mapnik::simplify_converter<mapnik::vertex_adapter> generalizer(path);
       if(m_algorithm)
         generalizer.set_simplify_algorithm(*m_algorithm);
       generalizer.set_simplify_tolerance(m_tolerance);
-      //suck the vertices back out of it
-      mapnik::geometry_type* output = new mapnik::geometry_type(geom.type());
+      // suck the vertices back out of it. note: keep the geometry in a smart
+      // pointer type in case ::push_vertex fails below and we get an exception.
+      std::unique_ptr<mapnik::geometry_type> output(new mapnik::geometry_type(geom.type()));
       mapnik::CommandType cmd;
       double x, y;
       while((cmd = (mapnik::CommandType)generalizer.vertex(&x, &y)) != mapnik::SEG_END)
       {
         output->push_vertex(x, y, cmd);
       }
-      //and put it back, note that this returns a pointer to the old one
-      //but it will get deallocated (auto_ptr) when it goes out of scope
-      feat->paths().replace(i, output);
+      // and put it back, note that this returns a pointer of unspecified
+      // smart type to the old one, which means it will get safely deallocated
+      // when it goes out of scope
+      feat->paths().replace(i, output.release());
     }
   }
 }

--- a/src/render_vector_tile.cpp
+++ b/src/render_vector_tile.cpp
@@ -3,7 +3,6 @@
 
 #include <mapnik/map.hpp>
 #include <mapnik/feature.hpp>
-#include <mapnik/graphics.hpp>
 #include <mapnik/attribute.hpp>
 #include <mapnik/request.hpp>
 #include <mapnik/agg_renderer.hpp>
@@ -11,7 +10,6 @@
 #include <mapnik/projection.hpp>
 #include <mapnik/scale_denominator.hpp>
 
-#include "mapnik3x_compatibility.hpp"
 #include "vector_tile_datasource.hpp"
 
 namespace avecado {
@@ -25,13 +23,13 @@ namespace {
  * the two can be different due to overzooming.
  */
 void process_layers(std::vector<mapnik::layer> const &layers,
-                    mapnik::vector::tile const &tile,
+                    vector_tile::Tile const &tile,
                     mapnik::request &request,
                     unsigned int z, unsigned int x, unsigned int y,
                     mapnik::projection const &projection,
                     double scale_denom,
                     mapnik::attributes const &variables,
-                    mapnik::agg_renderer<mapnik::image_32> &renderer) {
+                    mapnik::agg_renderer<mapnik::image_rgba8> &renderer) {
   for (auto const &layer : layers) {
 
     if (layer.visible(scale_denom)) {
@@ -45,7 +43,7 @@ void process_layers(std::vector<mapnik::layer> const &layers,
           mapnik::layer layer_copy(layer);
 
           layer_copy.set_datasource(
-            std::make_shared<mapnik::vector::tile_datasource>(
+            std::make_shared<mapnik::vector_tile_impl::tile_datasource>(
               layer_data, x, y, z, request.width()));
 
           std::set<std::string> names;
@@ -62,19 +60,19 @@ void process_layers(std::vector<mapnik::layer> const &layers,
 
 } // anonymous namespace
 
-bool render_vector_tile(mapnik::image_32 &image,
+bool render_vector_tile(mapnik::image_rgba8 &image,
                         tile &avecado_tile,
                         mapnik::Map const &map,
                         double scale_factor,
                         unsigned int buffer_size) {
 
-  typedef mapnik::agg_renderer<mapnik::image_32> renderer_type;
+  typedef mapnik::agg_renderer<mapnik::image_rgba8> renderer_type;
 
   // TODO: find out what these are supposed to be, and where we're supposed to get
   // them from.
   mapnik::attributes variables;
 
-  mapnik::vector::tile const &tile = avecado_tile.mapnik_tile();
+  vector_tile::Tile const &tile = avecado_tile.mapnik_tile();
 
   mapnik::request request(map.width(),
                           map.height(),

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -7,7 +7,7 @@
 namespace avecado {
 
 tile::tile(unsigned int z_, unsigned int x_, unsigned int y_)
-  : z(z_), x(x_), y(y_), m_mapnik_tile(new mapnik::vector::tile) {
+  : z(z_), x(x_), y(y_), m_mapnik_tile(new vector_tile::Tile) {
 }
 
 tile::~tile() {
@@ -26,11 +26,11 @@ void tile::from_string(const std::string &str) {
   m_mapnik_tile.swap(t.m_mapnik_tile);
 }
 
-mapnik::vector::tile const &tile::mapnik_tile() const {
+vector_tile::Tile const &tile::mapnik_tile() const {
   return *m_mapnik_tile;
 }
 
-mapnik::vector::tile &tile::mapnik_tile() {
+vector_tile::Tile &tile::mapnik_tile() {
   return *m_mapnik_tile;
 }
 

--- a/src/tilejson.cpp
+++ b/src/tilejson.cpp
@@ -220,7 +220,7 @@ std::string make_tilejson(const mapnik::Map &map,
   for (auto const &row : params) {
     out << "\"" << row.first << "\":";
     if (array_keys.count(row.first) > 0) {
-      out << "[" << row.second << "]";
+      out << "[" << row.second.get<std::string>() << "]";
     } else {
       mapnik::util::apply_visitor(json_converter(out), row.second);
     }

--- a/src/util_tile.cpp
+++ b/src/util_tile.cpp
@@ -41,7 +41,7 @@ struct minmax {
 
 } // anonymous namespace
 
-bool is_interesting(const mapnik::vector::tile_layer &l) {
+bool is_interesting(const vector_tile::Tile_Layer &l) {
   // empty features are not interesting
   if (l.features_size() == 0) {
     return false;
@@ -54,7 +54,7 @@ bool is_interesting(const mapnik::vector::tile_layer &l) {
 
   // now we know there's one feature, we can see if the
   // geometry is interesting, which means decoding the tile.
-  const mapnik::vector::tile_feature &f = l.features(0);
+  const vector_tile::Tile_Feature &f = l.features(0);
 
   const int32_t extent = l.extent();
   const uint32_t geometry_size = f.geometry_size();

--- a/test/adminizer.cpp
+++ b/test/adminizer.cpp
@@ -53,7 +53,8 @@ void assert_line_geom_equal(mapnik::feature_ptr &feat,
   auto itr = coords.begin();
   auto end = coords.end();
   auto expect_cmd = mapnik::SEG_MOVETO;
-  geom.rewind(0);
+  mapnik::vertex_adapter path(geom);
+  path.rewind(0);
 
   double expect_x = -1, expect_y = -1, actual_x = -1, actual_y = -1;
 
@@ -62,7 +63,7 @@ void assert_line_geom_equal(mapnik::feature_ptr &feat,
     if (itr == end) { break; }
     expect_y = *itr++;
 
-    auto actual_cmd = geom.vertex(&actual_x, &actual_y);
+    auto actual_cmd = path.vertex(&actual_x, &actual_y);
 
     test::assert_equal<unsigned int>(actual_cmd, expect_cmd, "command");
     test::assert_equal<double>(actual_x, expect_x, "x");
@@ -86,14 +87,15 @@ void assert_points_geom_equal(mapnik::feature_ptr &feat,
 
   auto itr = coords.begin();
   auto end = coords.end();
-  geom.rewind(0);
+  mapnik::vertex_adapter path(geom);
+  path.rewind(0);
 
   double expect_x = -1, expect_y = -1, actual_x = -1, actual_y = -1;
 
   while (itr != end) {
     boost::tie(expect_x, expect_y) = *itr++;
 
-    unsigned int actual_cmd = geom.vertex(&actual_x, &actual_y);
+    unsigned int actual_cmd = path.vertex(&actual_x, &actual_y);
 
     test::assert_equal<unsigned int>(actual_cmd, mapnik::SEG_MOVETO, "command");
     test::assert_equal<double>(actual_x, expect_x, "x");
@@ -120,8 +122,9 @@ void assert_wkt_geom_equal(mapnik::feature_ptr &feat, const std::string &wkt) {
   // until the test has a spurious failure because of re-ordering, let's
   // just assume the ordering remains the same.
   for (size_t i = 0; i < num_paths; ++i) {
-    const geometry_type &actual = actual_paths[i];
-    const geometry_type &expected = expected_paths[i];
+    const geometry_type &actual_geom = actual_paths[i];
+    const geometry_type &expected_geom = expected_paths[i];
+    mapnik::vertex_adapter actual(actual_geom), expected(expected_geom);
 
     test::assert_equal<geometry_type::types>(actual.type(), expected.type(),
                                              "geometry types");
@@ -322,11 +325,12 @@ void test_intersection_mode_split() {
       test::assert_equal<geometry_type::types>(geom.type(), geometry_type::LineString,
                                                "geometry should be LineString");
 
-      geom.rewind(0);
+      mapnik::vertex_adapter path(geom);
+      path.rewind(0);
       double x = 0, y = 0;
       unsigned int cmd = 0;
 
-      while ((cmd = geom.vertex(&x, &y)) != mapnik::SEG_END) {
+      while ((cmd = path.vertex(&x, &y)) != mapnik::SEG_END) {
         // we're expecting segments running L->R starting at x = -1, 0 & 3
         if (cmd == mapnik::SEG_MOVETO) {
           if (std::abs(x + 1.0) < 1.0e-6) {
@@ -400,11 +404,12 @@ void test_intersection_mode_split_first() {
       test::assert_equal<geometry_type::types>(geom.type(), geometry_type::LineString,
                                                "geometry should be LineString");
 
-      geom.rewind(0);
+      mapnik::vertex_adapter path(geom);
+      path.rewind(0);
       double x = 0, y = 0;
       unsigned int cmd = 0;
 
-      while ((cmd = geom.vertex(&x, &y)) != mapnik::SEG_END) {
+      while ((cmd = path.vertex(&x, &y)) != mapnik::SEG_END) {
         // we're expecting segments running L->R starting at x = -1, 0, 3 & 4
         if (cmd == mapnik::SEG_MOVETO) {
           if (std::abs(x + 1.0) < 1.0e-6) {
@@ -490,11 +495,12 @@ void test_intersection_mode_split_collect() {
       test::assert_equal<geometry_type::types>(geom.type(), geometry_type::LineString,
                                                "geometry should be LineString");
 
-      geom.rewind(0);
+      mapnik::vertex_adapter path(geom);
+      path.rewind(0);
       double x = 0, y = 0;
       unsigned int cmd = 0;
 
-      while ((cmd = geom.vertex(&x, &y)) != mapnik::SEG_END) {
+      while ((cmd = path.vertex(&x, &y)) != mapnik::SEG_END) {
         // we're expecting segments running L->R starting at x = -1, 0, 1, 3 & 4
         if (cmd == mapnik::SEG_MOVETO) {
           if (std::abs(x + 1.0) < 1.0e-6) {

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -178,8 +178,9 @@ std::string to_string(const mapnik::geometry_type& a) {
   std::string result = "{";
   //for each vertex
   double ax=0, ay=1;
-  for(size_t i = 0; i < a.size(); ++i) {
-    a.vertex(i, &ax, &ay);
+  mapnik::vertex_adapter va(a);
+  for(size_t i = 0; i < va.size(); ++i) {
+    va.vertex(i, &ax, &ay);
     result += (boost::format("[%3.1f, %3.1f],") % ax % ay).str();
   }
   if(result.back() == ',')
@@ -256,11 +257,12 @@ bool equal(const mapnik::geometry_type& a, const mapnik::geometry_type& b) {
     return false;
 
   //check every vertex
+  mapnik::vertex_adapter va(a), vb(b);
   double ax=0, ay=1, bx=2, by=3;
-  for(size_t i = 0; i < a.size(); ++i) {
-    a.vertex(i, &ax, &ay);
-    b.vertex(i, &bx, &by);
-    if(ax != bx || ay != by)
+  for(size_t i = 0; i < va.size(); ++i) {
+    int cmda = va.vertex(i, &ax, &ay);
+    int cmdb = vb.vertex(i, &bx, &by);
+    if(cmda != cmdb || ax != bx || ay != by)
       return false;
   }
 

--- a/test/generalizer.cpp
+++ b/test/generalizer.cpp
@@ -52,11 +52,13 @@ void test_generalize_to_straight() {
   test::assert_equal<size_t>(geom.size(), 2);
   double x = -1, y = -1;
 
-  test::assert_equal<unsigned int>(geom.vertex(0, &x, &y), mapnik::SEG_MOVETO);
+  mapnik::vertex_adapter path(geom);
+
+  test::assert_equal<unsigned int>(path.vertex(0, &x, &y), mapnik::SEG_MOVETO);
   test::assert_equal<double>(x, 0);
   test::assert_equal<double>(y, 0);
 
-  test::assert_equal<unsigned int>(geom.vertex(1, &x, &y), mapnik::SEG_LINETO);
+  test::assert_equal<unsigned int>(path.vertex(1, &x, &y), mapnik::SEG_LINETO);
   test::assert_equal<double>(x, 4);
   test::assert_equal<double>(y, 0);
 }

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -233,7 +233,7 @@ void test_tile_is_not_compressed() {
   // because it needs to avoid any automatic ungzipping.
   stream.seekp(0);
   google::protobuf::io::IstreamInputStream gstream(&stream);
-  mapnik::vector::tile tile;
+  vector_tile::Tile tile;
   bool read_ok = tile.ParseFromZeroCopyStream(&gstream);
   test::assert_equal<bool>(read_ok, true, "tile was plain PBF");
 }

--- a/test/make_vector_tile.cpp
+++ b/test/make_vector_tile.cpp
@@ -70,13 +70,13 @@ void test_single_point() {
                             scaling_method, scale_denominator, boost::none);
   avecado::tile tile2(_z, _x, _y);
   tile2.from_string(tile.get_data());
-  const mapnik::vector::tile &result = tile2.mapnik_tile();
+  const vector_tile::Tile &result = tile2.mapnik_tile();
 
   test::assert_equal(result.layers_size(), 1, "Wrong number of layers");
-  mapnik::vector::tile_layer layer = result.layers(0);
+  vector_tile::Tile_Layer layer = result.layers(0);
 
   // Query the layer with mapnik. See https://github.com/mapbox/mapnik-vector-tile/blob/2e3e2c28/test/vector_tile.cpp#L236
-  mapnik::vector::tile_datasource ds(layer, 0, 0, 0, tile_size);
+  mapnik::vector_tile_impl::tile_datasource ds(layer, 0, 0, 0, tile_size);
 
   mapnik::query qq = mapnik::query(bbox);
   qq.add_property_name("name");
@@ -98,13 +98,13 @@ void test_single_line() {
                             scaling_method, scale_denominator, boost::none);
   avecado::tile tile2(_z, _x, _y);
   tile2.from_string(tile.get_data());
-  const mapnik::vector::tile &result = tile2.mapnik_tile();
+  const vector_tile::Tile &result = tile2.mapnik_tile();
 
   test::assert_equal(result.layers_size(), 1, "Wrong number of layers");
-  mapnik::vector::tile_layer layer = result.layers(0);
+  vector_tile::Tile_Layer layer = result.layers(0);
 
   // Query the layer with mapnik. See https://github.com/mapbox/mapnik-vector-tile/blob/2e3e2c28/test/vector_tile.cpp#L236
-  mapnik::vector::tile_datasource ds(layer, 0, 0, 0, tile_size);
+  mapnik::vector_tile_impl::tile_datasource ds(layer, 0, 0, 0, tile_size);
 
   mapnik::query qq = mapnik::query(bbox);
   qq.add_property_name("name");
@@ -126,13 +126,13 @@ void test_single_polygon() {
                             scaling_method, scale_denominator, boost::none);
   avecado::tile tile2(_z, _x, _y);
   tile2.from_string(tile.get_data());
-  const mapnik::vector::tile &result = tile2.mapnik_tile();
+  const vector_tile::Tile &result = tile2.mapnik_tile();
 
   test::assert_equal(result.layers_size(), 1, "Wrong number of layers");
-  mapnik::vector::tile_layer layer = result.layers(0);
+  vector_tile::Tile_Layer layer = result.layers(0);
 
   // Query the layer with mapnik. See https://github.com/mapbox/mapnik-vector-tile/blob/2e3e2c28/test/vector_tile.cpp#L236
-  mapnik::vector::tile_datasource ds(layer, 0, 0, 0, tile_size);
+  mapnik::vector_tile_impl::tile_datasource ds(layer, 0, 0, 0, tile_size);
 
   mapnik::query qq = mapnik::query(bbox);
   qq.add_property_name("name");
@@ -154,14 +154,14 @@ void test_intersected_line() {
                             scaling_method, scale_denominator, boost::none);
   avecado::tile tile2(_z, _x, _y);
   tile2.from_string(tile.get_data());
-  const mapnik::vector::tile &result = tile2.mapnik_tile();
+  const vector_tile::Tile &result = tile2.mapnik_tile();
 
   test::assert_equal(result.layers_size(), 1, "Wrong number of layers");
-  mapnik::vector::tile_layer layer = result.layers(0);
+  vector_tile::Tile_Layer layer = result.layers(0);
 
   // Query the layer with mapnik. See https://github.com/mapbox/mapnik-vector-tile/blob/2e3e2c28/test/vector_tile.cpp#L236
   // note tile_datasource has x, y, z
-  mapnik::vector::tile_datasource ds(layer, 0, 0, 1, tile_size);
+  mapnik::vector_tile_impl::tile_datasource ds(layer, 0, 0, 1, tile_size);
 
   mapnik::query qq = mapnik::query(avecado::util::box_for_tile(1, 0, 0));
   qq.add_property_name("name");

--- a/test/multi_verification.cpp
+++ b/test/multi_verification.cpp
@@ -63,13 +63,13 @@ void test_multiline() {
                             scaling_method, scale_denominator, boost::none);
   avecado::tile tile2(_z, _x, _y);
   tile2.from_string(tile.get_data());
-  const mapnik::vector::tile &result = tile2.mapnik_tile();
+  const vector_tile::Tile &result = tile2.mapnik_tile();
 
   test::assert_equal(result.layers_size(), 1, "Wrong number of layers");
-  mapnik::vector::tile_layer layer = result.layers(0);
+  vector_tile::Tile_Layer layer = result.layers(0);
   test::assert_equal(layer.name(), std::string ("point"), "Wrong layer name");
   test::assert_equal(layer.features_size(), 1, "Wrong number of features");
-  mapnik::vector::tile_feature feature = layer.features(0);
+  vector_tile::Tile_Feature feature = layer.features(0);
   test::assert_equal(int(feature.type()), 2, "Wrong feature type");
   // The geometry should be a move to, lineto, moveto, lineto
   test::assert_equal(feature.geometry_size(), 12, "Wrong feature geometry length");
@@ -83,7 +83,7 @@ void test_multiline() {
   /* If we're this far, the PBF checks out */
 
   // Query the layer with mapnik. See https://github.com/mapbox/mapnik-vector-tile/blob/2e3e2c28/test/vector_tile.cpp#L236
-  mapnik::vector::tile_datasource ds(layer, 0, 0, 0, tile_size);
+  mapnik::vector_tile_impl::tile_datasource ds(layer, 0, 0, 0, tile_size);
 
   mapnik::query qq = mapnik::query(bbox);
   qq.add_property_name("name");
@@ -94,10 +94,11 @@ void test_multiline() {
   test::assert_equal(feat->get_geometry(0).size(),size_t(4),"Wrong feature geometry length");
   // We should have the same moveto lineto moveto lineto as above
   double x, y = -1;
-  test::assert_equal<unsigned int>(feat->get_geometry(0).vertex(0, &x, &y),mapnik::SEG_MOVETO, "First command should be SEG_MOVETO");
-  test::assert_equal<unsigned int>(feat->get_geometry(0).vertex(1, &x, &y),mapnik::SEG_LINETO, "Second command should be SEG_LINETO");
-  test::assert_equal<unsigned int>(feat->get_geometry(0).vertex(2, &x, &y),mapnik::SEG_MOVETO, "Second command should be SEG_MOVETO");
-  test::assert_equal<unsigned int>(feat->get_geometry(0).vertex(3, &x, &y),mapnik::SEG_LINETO, "Second command should be SEG_LINETO");
+  mapnik::vertex_adapter path(feat->get_geometry(0));
+  test::assert_equal<unsigned int>(path.vertex(0, &x, &y),mapnik::SEG_MOVETO, "First command should be SEG_MOVETO");
+  test::assert_equal<unsigned int>(path.vertex(1, &x, &y),mapnik::SEG_LINETO, "Second command should be SEG_LINETO");
+  test::assert_equal<unsigned int>(path.vertex(2, &x, &y),mapnik::SEG_MOVETO, "Second command should be SEG_MOVETO");
+  test::assert_equal<unsigned int>(path.vertex(3, &x, &y),mapnik::SEG_LINETO, "Second command should be SEG_LINETO");
   // MULTILINESTRINGs don't work with GeoJSON, see mapnik/mapnik#2518
 }
 
@@ -115,13 +116,13 @@ void test_multipolygon() {
                             scaling_method, scale_denominator, boost::none);
   avecado::tile tile2(_z, _x, _y);
   tile2.from_string(tile.get_data());
-  const mapnik::vector::tile &result = tile2.mapnik_tile();
+  const vector_tile::Tile &result = tile2.mapnik_tile();
 
   test::assert_equal(result.layers_size(), 1, "Wrong number of layers");
-  mapnik::vector::tile_layer layer = result.layers(0);
+  vector_tile::Tile_Layer layer = result.layers(0);
   test::assert_equal(layer.name(), std::string ("point"), "Wrong layer name");
   test::assert_equal(layer.features_size(), 1, "Wrong number of features");
-  mapnik::vector::tile_feature feature = layer.features(0);
+  vector_tile::Tile_Feature feature = layer.features(0);
   test::assert_equal(int(feature.type()), 3, "Wrong feature type");
   // The geometry should be a move to, lineto, moveto, lineto
   test::assert_equal(feature.geometry_size(), 37, "Wrong feature geometry length");

--- a/test/render_vector_tile.cpp
+++ b/test/render_vector_tile.cpp
@@ -9,7 +9,6 @@
 #include <mapnik/wkt/wkt_factory.hpp>
 #include <mapnik/wkt/wkt_grammar.hpp>
 #include <mapnik/wkt/wkt_grammar_impl.hpp>
-#include <mapnik/graphics.hpp>
 #include <mapnik/symbolizer.hpp>
 #include <mapnik/symbolizer_keys.hpp>
 #include <mapnik/symbolizer_utils.hpp>
@@ -23,7 +22,7 @@ namespace {
 
 void test_empty() {
   mapnik::color background_colour(0x8c, 0xc6, 0x3f);
-  mapnik::image_32 image(256, 256);
+  mapnik::image_rgba8 image(256, 256);
   avecado::tile tile(0, 0, 0);
   mapnik::Map map(256, 256);
   map.set_background(background_colour);
@@ -32,10 +31,10 @@ void test_empty() {
 
   test::assert_equal<bool>(status, true, "should have rendered an image");
 
-  const unsigned int rgba = background_colour.rgba();
+  const rgba8_t::type rgba = background_colour.rgba();
   for (unsigned int y = 0; y < image.height(); ++y) {
     for (unsigned int x = 0; x < image.width(); ++x) {
-      test::assert_equal<unsigned int>(image.data()(x, y), rgba, "should have set background colour");
+      test::assert_equal<rgba8_t::type>(image(x, y), rgba, "should have set background colour");
     }
   }
 }
@@ -43,7 +42,7 @@ void test_empty() {
 void test_full() {
   mapnik::color background_colour(0x8c, 0xc6, 0x3f);
   mapnik::color fill_colour(0x51, 0x21, 0x4d);
-  mapnik::image_32 image(256, 256);
+  mapnik::image_rgba8 image(256, 256);
 
   mapnik::Map map(256, 256);
   {
@@ -68,12 +67,12 @@ void test_full() {
 
   avecado::tile tile(0, 0, 0);
   {
-    mapnik::vector::tile_layer *layer = tile.mapnik_tile().add_layers();
+    vector_tile::Tile_Layer *layer = tile.mapnik_tile().add_layers();
     layer->set_version(1);
     layer->set_name("layer");
-    mapnik::vector::tile_feature *feature = layer->add_features();
+    vector_tile::Tile_Feature *feature = layer->add_features();
     feature->set_id(1);
-    feature->set_type(mapnik::vector::tile::Polygon);
+    feature->set_type(vector_tile::Tile::POLYGON);
     // this strange sequence of numbers comes from cranking the mapnik vector
     // tile geometry algorithm by hand on a [-180 -90, 180 90] box.
     for (uint32_t g : {9, 0, 128, 26, 512, 0, 0, 256, 511, 0, 7}) {
@@ -86,10 +85,10 @@ void test_full() {
 
   test::assert_equal<bool>(status, true, "should have rendered an image");
 
-  const unsigned int rgba = fill_colour.rgba();
+  const rgba8_t::type rgba = fill_colour.rgba();
   for (unsigned int y = 0; y < image.height(); ++y) {
     for (unsigned int x = 0; x < image.width(); ++x) {
-      test::assert_equal<unsigned int>(image.data()(x, y), rgba, "should have set fill colour");
+      test::assert_equal<rgba8_t::type>(image(x, y), rgba, "should have set fill colour");
     }
   }
 }

--- a/test/util_tile.cpp
+++ b/test/util_tile.cpp
@@ -8,7 +8,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/format.hpp>
 
-using mapnik::vector::tile_layer;
+using tile_layer = vector_tile::Tile_Layer;
 
 namespace {
 
@@ -20,9 +20,9 @@ void test_cover_empty() {
 void test_cover_full() {
   tile_layer l;
   l.set_name("boundingbox");
-  mapnik::vector::tile_feature *feat = l.add_features();
+  vector_tile::Tile_Feature *feat = l.add_features();
   feat->set_id(1);
-  feat->set_type(mapnik::vector::tile::Polygon);
+  feat->set_type(vector_tile::Tile::POLYGON);
   for (uint32_t i : {9, 63, 8256, 26, 0, 8319, 8320, 0, 0, 8320, 15}) {
     feat->add_geometry(i);
   }
@@ -36,9 +36,9 @@ void test_cover_full() {
 void test_cover_full_degenerate() {
   tile_layer l;
   l.set_name("water");
-  mapnik::vector::tile_feature *feat = l.add_features();
+  vector_tile::Tile_Feature *feat = l.add_features();
   feat->set_id(2);
-  feat->set_type(mapnik::vector::tile::Polygon);
+  feat->set_type(vector_tile::Tile::POLYGON);
   for (uint32_t i : {9, 63, 8256, 58, 0, 8319, 8320, 0, 0, 8320, 8319,
         0, 8320, 0, 8319, 0, 8320, 0, 15}) {
     feat->add_geometry(i);
@@ -53,9 +53,9 @@ void test_cover_many() {
   tile_layer l;
   l.set_name("boundingbox");
   for (int32_t id : {1, 2}) {
-    mapnik::vector::tile_feature *feat = l.add_features();
+    vector_tile::Tile_Feature *feat = l.add_features();
     feat->set_id(id);
-    feat->set_type(mapnik::vector::tile::Polygon);
+    feat->set_type(vector_tile::Tile::POLYGON);
     for (uint32_t i : {9, 63, 8256, 26, 0, 8319, 8320, 0, 0, 8320, 15}) {
       feat->add_geometry(i);
     }
@@ -70,9 +70,9 @@ void test_cover_many() {
 void test_cover_shape() {
   tile_layer l;
   l.set_name("boundingbox");
-  mapnik::vector::tile_feature *feat = l.add_features();
+  vector_tile::Tile_Feature *feat = l.add_features();
   feat->set_id(1);
-  feat->set_type(mapnik::vector::tile::Polygon);
+  feat->set_type(vector_tile::Tile::POLYGON);
   for (uint32_t i : {9, 63, 8256, 26, 0, 8319, 8320, 0, 0, 8320, 15}) {
     feat->add_geometry(i);
   }


### PR DESCRIPTION
This fixes Avecado so that it can compile against the latest (at time of writing) version of Mapnik. It also updates the `mapnik-vector-tiles` dependency to the latest version of that.

It should compile (although still not cleanly - need the Boost MPL defines still) and tests pass.