### PR TITLE
Fixes for Mapnik 7ee9745

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Avecado uses the [GNU Build System](http://www.gnu.org/software/automake/manual/
 
     sudo apt-get install build-essential autoconf automake libtool libboost-all-dev python-dev libprotobuf-dev protobuf-compiler
 
-You will also need to install a 3.x version of the Mapnik library. This version of the library was tested with commit `87e9c64f` from [Mapnik master](https://github.com/mapnik/mapnik).
+You will also need to install a 3.x version of the Mapnik library. This version of the library was tested with commit `7ee9745` from [Mapnik master](https://github.com/mapnik/mapnik).
 
 Then you should be able to bootstrap the build system:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Avecado embeds [mapnik-vector-tile](https://github.com/mapbox/mapnik-vector-tile
 as a subrepository. Its version needs to match with Mapnik's. If building on a
 system with an older or newer Mapnik, an older or newer version of
 mapnik-vector-tile should be used. The version of Mapnik used when testing
-this version of Avecado was `87e9c64f`. This is complicated, but should stabilize
+this version of Avecado was `7ee9745`. This is complicated, but should stabilize
 when Mapnik 3 is released.
 
 ## Components ##

--- a/src/tilejson.cpp
+++ b/src/tilejson.cpp
@@ -122,6 +122,14 @@ struct json_converter : public mapnik::util::static_visitor<> {
     out << "null";
   }
 
+  void operator()(const mapnik::value_bool &b) const {
+    if (b) {
+      out << "true";
+    } else {
+      out << "false";
+    }
+  }
+
   void operator()(const mapnik::value_integer &i) const {
     out << i;
   }
@@ -138,6 +146,10 @@ struct json_converter : public mapnik::util::static_visitor<> {
 struct force_integer : public mapnik::util::static_visitor<mapnik::value_integer> {
   mapnik::value_integer operator()(const mapnik::value_null &) const {
     return mapnik::value_integer(0);
+  }
+
+  mapnik::value_integer operator()(const mapnik::value_bool &b) const {
+    return mapnik::value_integer(b ? 1 : 0);
   }
 
   mapnik::value_integer operator()(const mapnik::value_integer &i) const {

--- a/test/render_vector_tile.cpp
+++ b/test/render_vector_tile.cpp
@@ -31,10 +31,10 @@ void test_empty() {
 
   test::assert_equal<bool>(status, true, "should have rendered an image");
 
-  const rgba8_t::type rgba = background_colour.rgba();
+  const mapnik::rgba8_t::type rgba = background_colour.rgba();
   for (unsigned int y = 0; y < image.height(); ++y) {
     for (unsigned int x = 0; x < image.width(); ++x) {
-      test::assert_equal<rgba8_t::type>(image(x, y), rgba, "should have set background colour");
+      test::assert_equal<mapnik::rgba8_t::type>(image(x, y), rgba, "should have set background colour");
     }
   }
 }
@@ -85,10 +85,10 @@ void test_full() {
 
   test::assert_equal<bool>(status, true, "should have rendered an image");
 
-  const rgba8_t::type rgba = fill_colour.rgba();
+  const mapnik::rgba8_t::type rgba = fill_colour.rgba();
   for (unsigned int y = 0; y < image.height(); ++y) {
     for (unsigned int x = 0; x < image.width(); ++x) {
-      test::assert_equal<rgba8_t::type>(image(x, y), rgba, "should have set fill colour");
+      test::assert_equal<mapnik::rgba8_t::type>(image(x, y), rgba, "should have set fill colour");
     }
   }
 }


### PR DESCRIPTION
Updating to Mapnik 7ee9745 caused a couple of compile failures. Luckily, they were pretty easy to fix.

1. There's a `value_bool` element in the `mapnik::value` variant, which needs handling in the visitors.
2. The pixel types, such as `rgba8_t`, moved into the `mapnik` namespace.
