### PR TITLE
Use gzip compression for tiles instead of deflate

### DIFF
--- a/src/avecado_server.cpp
+++ b/src/avecado_server.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[]) {
      "Maximum age, in seconds, to cache generated files for.")
     ("compression-level,z", bpo::value<int>(&srv_opts.compression_level)
      ->default_value(-1),
-     "Zlib compression level: 0 means no compression, 1 is fastest, "
+     "Gzip compression level: 0 means no compression, 1 is fastest, "
      "9 is best compression. Leave as -1 to use the default.")
     // positional arguments
     ("map-file", bpo::value<std::string>(&srv_opts.map_file), "Mapnik XML input file.")

--- a/src/http_server/request_handler.cpp
+++ b/src/http_server/request_handler.cpp
@@ -156,7 +156,7 @@ void request_handler::handle_request_tile(const request &req, reply &rep,
   rep.status = reply::ok;
   rep.is_hard_error = false;
   rep.content = painted ? tile.get_data(options_.compression_level) : "";
-  rep.headers.resize(6);
+  rep.headers.resize(7);
   rep.headers[0].name = "Content-Length";
   rep.headers[0].value = boost::lexical_cast<std::string>(rep.content.size());
   rep.headers[1].name = "Content-Type";
@@ -169,6 +169,16 @@ void request_handler::handle_request_tile(const request &req, reply &rep,
   rep.headers[4].value = max_age_value_;
   rep.headers[5].name = "Date";
   rep.headers[5].value = make_http_date();
+  // make sure that the response header is set appropriately for the level
+  // of compression that we are applying, so that the client doesn't have
+  // to inspect the file and try to figure out if it's supposed to be
+  // compressed or not.
+  rep.headers[6].name = "Content-Encoding";
+  if (options_.compression_level == 0) {
+    rep.headers[6].value = "identity";
+  } else {
+    rep.headers[6].value = "gzip";
+  }
 }
 
 bool request_handler::url_decode(const std::string& in, std::string& out)

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -58,7 +58,7 @@ std::ostream &operator<<(std::ostream &out, const tile_gzip &t) {
     if (t.compression_level_ >= 0) {
       options.compression_level = t.compression_level_;
     }
-    options.format = google::protobuf::io::GzipOutputStream::ZLIB;
+    options.format = google::protobuf::io::GzipOutputStream::GZIP;
     google::protobuf::io::GzipOutputStream gz_stream(&stream, options);
 
     write_ok = t.tile_.mapnik_tile().SerializeToZeroCopyStream(&gz_stream);

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -202,12 +202,10 @@ void test_tile_is_compressed() {
 
   std::string data = stream.str();
   test::assert_greater_or_equal<size_t>(data.size(), 2, "tile size");
-  // see http://tools.ietf.org/html/rfc1950 for header magic values
-  test::assert_equal<uint32_t>(uint8_t(data[0]) & 0xf, 8, "compression method = deflate");
-  test::assert_less_or_equal<uint32_t>(uint8_t(data[0]) >> 4, 7, "window size <= 7");
-  test::assert_equal<uint32_t>(
-    (uint32_t(uint8_t(data[0])) * 256 + uint32_t(uint8_t(data[1]))) % 31,
-    0, "FCHECK checksum2");
+  // see https://tools.ietf.org/html/rfc1952#page-6 for header magic values
+  test::assert_equal<uint32_t>(uint8_t(data[0]), 0x1f, "gzip header magic ID1");
+  test::assert_equal<uint32_t>(uint8_t(data[1]), 0x8b, "gzip header magic ID2");
+  test::assert_equal<uint32_t>(uint8_t(data[2]), 0x08, "gzip compression method = deflate");
 }
 
 void test_tile_is_not_compressed() {


### PR DESCRIPTION
Turns out nobody wants deflate-compressed tiles. MBS expects gzip-compressed tiles (but doesn't set Accept-Encoding, see [this issue](https://github.com/mapbox/mapbox-studio/issues/1268) for more details) rather than deflate-compressed tiles, and browsers will accept either as long as the correct Accept-Encoding header is set.

This patch swaps deflate compression for gzip, and makes sure that the correct HTTP response header is set.