### PR TITLE
Use caps in Access-Control-Allow-Methods header

### DIFF
--- a/src/http_server/reply.cpp
+++ b/src/http_server/reply.cpp
@@ -254,7 +254,7 @@ reply reply::stock_reply(reply::status_type status)
   rep.headers[1].value = "text/html";
   rep.headers[2].name = "Access-Control-Allow-Origin";
   rep.headers[2].value = "*";
-  rep.headers[3].name= "access-control-allow-methods";
+  rep.headers[3].name= "Access-Control-Allow-Methods";
   rep.headers[3].value = "GET";
   return rep;
 }

--- a/src/http_server/request_handler.cpp
+++ b/src/http_server/request_handler.cpp
@@ -101,7 +101,7 @@ void request_handler::handle_request_json(const request &req, reply &rep) {
   rep.headers[1].value = "application/json";
   rep.headers[2].name = "Access-Control-Allow-Origin";
   rep.headers[2].value = "*";
-  rep.headers[3].name= "access-control-allow-methods";
+  rep.headers[3].name= "Access-Control-Allow-Methods";
   rep.headers[3].value = "GET";
   rep.headers[4].name = "Cache-control";
   rep.headers[4].value = max_age_value_;
@@ -163,7 +163,7 @@ void request_handler::handle_request_tile(const request &req, reply &rep,
   rep.headers[1].value = "application/octet-stream";
   rep.headers[2].name = "Access-Control-Allow-Origin";
   rep.headers[2].value = "*";
-  rep.headers[3].name= "access-control-allow-methods";
+  rep.headers[3].name= "Access-Control-Allow-Methods";
   rep.headers[3].value = "GET";
   rep.headers[4].name = "Cache-control";
   rep.headers[4].value = max_age_value_;


### PR DESCRIPTION
http://www.w3.org/TR/cors/#access-control-allow-methods-response-header gives the header in Title Case.

cc @zerebubuth @charterchap 